### PR TITLE
Call on_merge after merge + one assertion

### DIFF
--- a/src/cc/Sidekick_cc.ml
+++ b/src/cc/Sidekick_cc.ml
@@ -139,6 +139,17 @@ module Make(CC_A: ARG) = struct
 
   module N_tbl = CCHashtbl.Make(N)
 
+  (* non-recursive, inlinable function for [find] *)
+  let[@inline] find_ (n:node) : repr =
+    let n2 = n.n_root in
+    assert (N.is_root n2);
+    n2
+
+  let[@inline] same_class (n1:node)(n2:node): bool =
+    N.equal (find_ n1) (find_ n2)
+
+  let[@inline] find _ n = find_ n
+
   module Expl = struct
     type t = explanation
 
@@ -153,7 +164,9 @@ module Make(CC_A: ARG) = struct
 
     let mk_reduction : t = E_reduction
     let[@inline] mk_congruence n1 n2 : t = E_congruence (n1,n2)
-    let[@inline] mk_merge a b : t = if N.equal a b then mk_reduction else E_merge (a,b)
+    let[@inline] mk_merge a b : t = 
+      assert (same_class a b); 
+      if N.equal a b then mk_reduction else E_merge (a,b)
     let[@inline] mk_merge_t a b : t = if T.equal a b then mk_reduction else E_merge_t (a,b)
     let[@inline] mk_lit l : t = E_lit l
 
@@ -271,16 +284,6 @@ module Make(CC_A: ARG) = struct
      Invariant: [in_cc t ∧ do_cc t => forall u subterm t, in_cc u] *)
   let[@inline] mem (cc:t) (t:term): bool = T_tbl.mem cc.tbl t
 
-  (* non-recursive, inlinable function for [find] *)
-  let[@inline] find_ (n:node) : repr =
-    let n2 = n.n_root in
-    assert (N.is_root n2);
-    n2
-
-  let[@inline] same_class (n1:node)(n2:node): bool =
-    N.equal (find_ n1) (find_ n2)
-
-  let[@inline] find _ n = find_ n
 
   (* print full state *)
   let pp_full out (cc:t) : unit =

--- a/src/core/Sidekick_core.ml
+++ b/src/core/Sidekick_core.ml
@@ -210,14 +210,16 @@ module type CC_S = sig
   (** Add the term to the congruence closure, if not present already.
       Will be backtracked. *)
 
-  type ev_on_merge = t -> actions -> N.t -> N.t -> Expl.t -> unit
+  type ev_on_pre_merge = t -> actions -> N.t -> N.t -> Expl.t -> unit
+  type ev_on_post_merge = t -> actions -> N.t -> N.t -> unit
   type ev_on_new_term = t -> N.t -> term -> unit
   type ev_on_conflict = t -> lit list -> unit
   type ev_on_propagate = t -> lit -> (unit -> lit list) -> unit
 
   val create :
     ?stat:Stat.t ->
-    ?on_merge:ev_on_merge list ->
+    ?on_pre_merge:ev_on_pre_merge list ->
+    ?on_post_merge:ev_on_post_merge list ->
     ?on_new_term:ev_on_new_term list ->
     ?on_conflict:ev_on_conflict list ->
     ?on_propagate:ev_on_propagate list ->
@@ -231,7 +233,10 @@ module type CC_S = sig
       See {!N.bitfield}. *)
 
   (* TODO: remove? this is managed by the solver anyway? *)
-  val on_merge : t -> ev_on_merge -> unit
+  val on_pre_merge : t -> ev_on_pre_merge -> unit
+  (** Add a function to be called when two classes are merged *)
+  
+  val on_post_merge : t -> ev_on_post_merge -> unit
   (** Add a function to be called when two classes are merged *)
 
   val on_new_term : t -> ev_on_new_term -> unit
@@ -418,8 +423,11 @@ module type SOLVER_INTERNAL = sig
   (** Add/retrieve congruence closure node for this term.
       To be used in theories *)
 
-  val on_cc_merge : t -> (CC.t -> actions -> CC.N.t -> CC.N.t -> CC.Expl.t -> unit) -> unit
-  (** Callback for when two classes containing data for this key are merged *)
+  val on_cc_pre_merge : t -> (CC.t -> actions -> CC.N.t -> CC.N.t -> CC.Expl.t -> unit) -> unit
+  (** Callback for when two classes containing data for this key are merged (called before) *)
+
+  val on_cc_post_merge : t -> (CC.t -> actions -> CC.N.t -> CC.N.t -> unit) -> unit
+  (** Callback for when two classes containing data for this key are merged (called after)*)
 
   val on_cc_new_term : t -> (CC.t -> CC.N.t -> term -> unit) -> unit
   (** Callback to add data on terms when they are added to the congruence

--- a/src/msat-solver/Sidekick_msat_solver.ml
+++ b/src/msat-solver/Sidekick_msat_solver.ml
@@ -251,7 +251,8 @@ module Make(A : ARG)
     let on_final_check self f = self.on_final_check <- f :: self.on_final_check
     let on_partial_check self f = self.on_partial_check <- f :: self.on_partial_check
     let on_cc_new_term self f = CC.on_new_term (cc self) f
-    let on_cc_merge self f = CC.on_merge (cc self) f
+    let on_cc_pre_merge self f = CC.on_pre_merge (cc self) f
+    let on_cc_post_merge self f = CC.on_post_merge (cc self) f
     let on_cc_conflict self f = CC.on_conflict (cc self) f
     let on_cc_propagate self f = CC.on_propagate (cc self) f
 

--- a/src/th-cstor/Sidekick_th_cstor.ml
+++ b/src/th-cstor/Sidekick_th_cstor.ml
@@ -40,9 +40,9 @@ module Make(A : ARG) : S with module A = A = struct
     (* TODO: also allocate a bit in CC to filter out quickly classes without cstors *)
   }
 
-  let on_merge (solver:SI.t) n1 tc1 n2 tc2 e_n1_n2 : unit =
+  let on_pre_merge (solver:SI.t) n1 tc1 n2 tc2 e_n1_n2 : unit =
     Log.debugf 5
-      (fun k->k "(@[th-cstor.on_merge@ @[:c1 %a@ (term %a)@]@ @[:c2 %a@ (term %a)@]@])"
+      (fun k->k "(@[th-cstor.on_pre_merge@ @[:c1 %a@ (term %a)@]@ @[:c2 %a@ (term %a)@]@])"
           N.pp n1 T.pp tc1.t N.pp n2 T.pp tc2.t); 
     let expl = Expl.mk_list [e_n1_n2; Expl.mk_merge n1 tc1.n; Expl.mk_merge n2 tc2.n] in
     match A.view_as_cstor tc1.t, A.view_as_cstor tc2.t with
@@ -71,7 +71,7 @@ module Make(A : ARG) : S with module A = A = struct
       cstors=N_tbl.create 32;
     } in
     (* TODO
-    SI.on_cc_merge solver on_merge;
+    SI.on_cc_pre_merge solver on_pre_merge;
     SI.on_cc_new_term solver on_new_term;
        *)
     self


### PR DESCRIPTION
It seems more convenient to me to call the `on_merge` hook after the terms have been merged and not before. If you disagree, we might need two hooks.